### PR TITLE
feat(faq): add content to FAQ page from Alura's API

### DIFF
--- a/pages/faq/[slug].js
+++ b/pages/faq/[slug].js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FAQQuestion from '../../src/components/screens/FAQQuestions';
+import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
+
+function FAQAnswerPage({ category, question }) {
+  return (
+    <FAQQuestion category={category} question={question} />
+  );
+}
+
+export default websitePageHOC(FAQAnswerPage);
+
+export async function getStaticProps({ params }) {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
+    .then((response) => response.json())
+    .then((responseJson) => responseJson.data);
+
+  const questionPageData = faqCategories.reduce((valorAcumulado, faqCategory) => {
+    const questionData = faqCategory.questions.find((question) => {
+      if (question.slug === params.slug) {
+        return true;
+      }
+      return false;
+    });
+
+    return {
+      ...valorAcumulado,
+      category: faqCategory,
+      question: questionData,
+    };
+  }, {});
+
+  return {
+    props: {
+      category: questionPageData.category,
+      question: questionPageData.question,
+      pageWrapperProps: {
+        seoProps: {
+          headTitle: questionPageData.question.title,
+        },
+      },
+    },
+  };
+}
+
+export async function getStaticPaths() {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
+    .then((response) => response.json())
+    .then((responseJson) => responseJson.data);
+
+  const paths = faqCategories.reduce((valorAcumulado, faqCategory) => {
+    const pathsArray = faqCategory.questions.map((question) => (
+      { params: { slug: question.slug } }
+    ));
+
+    return [
+      ...valorAcumulado,
+      ...pathsArray,
+    ];
+  }, []);
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+FAQAnswerPage.propTypes = {
+  category: PropTypes.shape({
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    questions: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      slug: PropTypes.string,
+    })),
+  }).isRequired,
+  question: PropTypes.shape({
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
@@ -36,6 +37,8 @@ export const TextStyleVariantsMap = {
 const TextBase = styled.span`
   ${(props) => TextStyleVariantsMap[props.variant]}
   ${propToStyle('textAlign')}
+  ${propToStyle('marginBottom')}
+  ${propToStyle('display')}
   color: ${({ theme, color }) => get(theme, `colors.${color}.color`)};
 `;
 
@@ -52,7 +55,6 @@ export default function Text({
         as={Link}
         href={href}
         variant={variant}
-        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       >
         {children}
@@ -63,7 +65,6 @@ export default function Text({
     <TextBase
       as={tag}
       variant={variant}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       {children}

--- a/src/components/foundation/layout/Grid/index.js
+++ b/src/components/foundation/layout/Grid/index.js
@@ -25,7 +25,6 @@ const Container = styled.div`
   })}
 
   ${propToStyle('marginTop')}
-
 `;
 
 const Row = styled.div`
@@ -133,11 +132,11 @@ const Col = styled.div`
 
   ${propToStyle('display')}
   ${propToStyle('flexDirection')}
+  ${propToStyle('flex')}
+  ${propToStyle('order')}
   ${propToStyle('alignItems')}
   ${propToStyle('justifyContent')}
   ${propToStyle('paddingRight')}
-  ${propToStyle('flex')}
-  ${propToStyle('order')}
 `;
 
 Col.defaultProps = {

--- a/src/components/screens/FAQQuestions/index.js
+++ b/src/components/screens/FAQQuestions/index.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTheme } from 'styled-components';
+import Box from '../../foundation/layout/Box';
+import Grid from '../../foundation/layout/Grid';
+import Text from '../../foundation/Text';
+
+export default function FAQQuestion({ category, question }) {
+  const theme = useTheme();
+  return (
+    <Grid.Container
+      flex="1"
+      marginTop={{
+        xs: '32px',
+        md: '80px',
+      }}
+    >
+      <Grid.Row
+        flexDirection={{
+          xs: 'column-reverse',
+          md: 'row',
+        }}
+      >
+        <Grid.Col
+          offset={{
+            sm: 0,
+            lg: 1,
+          }}
+          value={{
+            xs: 12,
+            md: 4,
+            lg: 4,
+          }}
+        >
+          <Text
+            variant="title"
+            color="tertiary.main"
+            marginBottom="25px"
+          >
+            Artigos
+            <br />
+            Relacionados
+          </Text>
+          <Box
+            as="ul"
+            listStyle="none"
+            padding="24px 30px"
+            backgroundColor={theme.colors.borders.main.color}
+            borderRadiusTheme
+          >
+            {category.questions.map((currentQuestion) => (
+              <Text
+                key={currentQuestion.slug}
+                display="block"
+                variant="paragraph2"
+                href={`/faq/${currentQuestion.slug}`}
+                color="primary.main"
+                marginBottom="16px"
+              >
+                {currentQuestion.title}
+              </Text>
+            ))}
+          </Box>
+        </Grid.Col>
+
+        <Grid.Col
+          value={{
+            lg: 6,
+          }}
+          marginBottom={{
+            xs: '50px',
+            md: '0',
+          }}
+        >
+          <Text
+            variant="title"
+            color="tertiary.main"
+          >
+            {question.title}
+          </Text>
+          <Text
+            as="p"
+            variant="paragraph1"
+            color="tertiary.light"
+          >
+            {question.description }
+          </Text>
+        </Grid.Col>
+      </Grid.Row>
+    </Grid.Container>
+  );
+}
+
+FAQQuestion.propTypes = {
+  category: PropTypes.shape({
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    questions: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      slug: PropTypes.string,
+    })),
+  }).isRequired,
+  question: PropTypes.shape({
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -1,12 +1,20 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import WebsitePageWrapper from '..';
 import WebsiteGlobalProvider from '../provider';
 
-export default function websitePageHOC(PageComponent, { pageWrapperProps }) {
+export default function websitePageHOC(
+  PageComponent,
+  { pageWrapperProps } = { pageWrapperProps: {} },
+) {
   return (props) => (
     <WebsiteGlobalProvider>
-      <WebsitePageWrapper {...pageWrapperProps}>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+      >
         <PageComponent {...props} />
       </WebsitePageWrapper>
     </WebsiteGlobalProvider>


### PR DESCRIPTION
We created a "dynamic-static" page using Next's structure to populate FAQ answers page. Using the
API's page slug, we obtained the question's answer and category's other questions. We also changed
the websiteHOC component to receive pageWrapperProps from the component. This allowed the answer to
provide the Head Title of the page.